### PR TITLE
dev/translation#16 - Forum links are broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,18 @@ https://forum.civicrm.org/index.php/topic,19068.0.html
 Forums, help, community
 =======================
 
-For questions, please post on the Internationalisation forum:  
-http://forum.civicrm.org/index.php/board,10.0.html
+For questions, please post in the `translation` channel at https://chat.civicrm.org or on StackExchange at https://civicrm.stackexchange.com.  
+
+There are also a few language-specific channels at https://chat.civicrm.org, e.g. `francophone`, `nederlandstalig`, etc.
+
+Older, read-only information may be found on the Internationalisation forum:  
+https://forum.civicrm.org/index.php?board=10.0
 
 Or on the language-specific forums:
-* French: http://forum.civicrm.org/index.php/board,58.0.html
-* German: http://forum.civicrm.org/index.php/board,62.0.html
-* Spanish: http://forum.civicrm.org/index.php/board,69.0.html
-* UK: http://forum.civicrm.org/index.php/board,34.0.html
+* French: http://forum.civicrm.org/index.php?board=58.0
+* German: http://forum.civicrm.org/index.php?board=62.0
+* Spanish: http://forum.civicrm.org/index.php?board=69.0
+* UK: http://forum.civicrm.org/index.php?board=34.0
 
 
 Note about language/country ISO codes


### PR DESCRIPTION
As written the forum links give 404 errors, but also they aren't the current place to post new questions.