### PR TITLE
dev/core#495 - Administration pages field labels not getting translated

### DIFF
--- a/bin/create-pot-files.sh
+++ b/bin/create-pot-files.sh
@@ -208,7 +208,8 @@ function build_raw_pot() {
       _civistrings -o "$filepath" \
         {CRM,templates/CRM}/$name \
         ang/crmCxn* \
-        ang/crmStatusPage*
+        ang/crmStatusPage* \
+        settings/
       ;;
 
     Campaign)


### PR DESCRIPTION
I'm guessing this is the right line to add this but I'm not set up to test it. See https://lab.civicrm.org/dev/core/issues/495 and https://civicrm.stackexchange.com/questions/34173/first-colums-of-form-not-translated. Also note that many of the files in the settings folder don't use ts() but that seems like an oversight since some do, but even the ones that do aren't getting scanned.